### PR TITLE
fix: incorrect function name

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ class ServerlessLambdaEdgePreExistingCloudFront {
     const versions = await this.provider.request('Lambda', 'listVersionsByFunction', args)
 
     if (versions.NextMarker !== null) {
-      return await this.getlatestVersion(functionName, versions.NextMarker)
+      return await this.getlatestVersionLambdaArn(functionName, versions.NextMarker)
     }
     let arn
     versions.Versions.forEach(async (functionObj) => {


### PR DESCRIPTION
When the number of lambda function versions exceeds 50, the method `getlatestVersionLambdaArn` must recursively fetch one or more additional pages of results.  The recursive function call does not match the name of the parent function resulting in:

`TypeError: this.getlatestVersion is not a function
      at ServerlessLambdaEdgePreExistingCloudFront.getlatestVersionLambdaArn (index.js:124:25)`

This PR updates the function name to match.

