### PR TITLE
Add ConfigSchema to satisfy schema validation in Serverless 1.79.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,39 @@ class ServerlessLambdaEdgePreExistingCloudFront {
           }, Promise.resolve())
       }
     }
+
+    this.serverless.configSchemaHandler.defineCustomProperties({
+      type: 'object',
+      properties: {
+        lambdaEdgePreExistingCloudFront: {
+          type: 'object',
+          properties: {
+            validStages: {
+              type: 'array',
+              items: { type: 'string' },
+              uniqueItems: true
+            }
+          }
+        },
+      }
+    })
+
+    this.serverless.configSchemaHandler.defineFunctionEvent('aws', 'preExistingCloudFront', {
+      type: 'object',
+      properties: {
+        distributionId: { type: 'string' },
+        eventType: { type: 'string' },
+        pathPattern: { type: 'string' },
+        includeBody: { type: 'boolean' }
+      },
+      required: [
+        'distributionId',
+        'eventType',
+        'pathPattern',
+        'includeBody'
+      ]
+    })
+
   }
 
   checkAllowedDeployStage() {
@@ -129,6 +162,7 @@ class ServerlessLambdaEdgePreExistingCloudFront {
     })
     return arn
   }
+
 }
 
 module.exports = ServerlessLambdaEdgePreExistingCloudFront


### PR DESCRIPTION
I just upgraded my serverless cli to 1.79.0 and started seeing this warning when deploying:
```
Serverless: Configuration warning at 'functions.myLambdaFunction.events[0]': unsupported function event
Serverless:  
Serverless: If you prefer to not continue ensure "configValidationMode: error" in your config
Serverless: If errors are influenced by an external plugin, enquiry at plugin repository so schema extensions are added (https://www.serverless.com/framework/docs/providers/aws/guide/plugins#extending-validation-schema)
Serverless: If errors seem invalid, please report at https://github.com/serverless/serverless/issues/new?template=bug_report.md
Serverless: If you find this functionality problematic, you may turn it off with "configValidationMode: off" setting
```

This PR just defines the schema for custom properties and the preExistingCloudFront function event as per https://www.serverless.com/framework/docs/providers/aws/guide/plugins/#extending-validation-schema.