### PR TITLE
fix: make configSchemaHandler optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,38 +62,34 @@ class ServerlessLambdaEdgePreExistingCloudFront {
       }
     }
 
-    this.serverless.configSchemaHandler.defineCustomProperties({
-      type: 'object',
-      properties: {
-        lambdaEdgePreExistingCloudFront: {
-          type: 'object',
-          properties: {
-            validStages: {
-              type: 'array',
-              items: { type: 'string' },
-              uniqueItems: true
+    if (this.serverless.configSchemaHandler) {
+      this.serverless.configSchemaHandler.defineCustomProperties({
+        type: 'object',
+        properties: {
+          lambdaEdgePreExistingCloudFront: {
+            type: 'object',
+            properties: {
+              validStages: {
+                type: 'array',
+                items: { type: 'string' },
+                uniqueItems: true
+              }
             }
           }
+        }
+      })
+
+      this.serverless.configSchemaHandler.defineFunctionEvent('aws', 'preExistingCloudFront', {
+        type: 'object',
+        properties: {
+          distributionId: { type: 'string' },
+          eventType: { type: 'string' },
+          pathPattern: { type: 'string' },
+          includeBody: { type: 'boolean' }
         },
-      }
-    })
-
-    this.serverless.configSchemaHandler.defineFunctionEvent('aws', 'preExistingCloudFront', {
-      type: 'object',
-      properties: {
-        distributionId: { type: 'string' },
-        eventType: { type: 'string' },
-        pathPattern: { type: 'string' },
-        includeBody: { type: 'boolean' }
-      },
-      required: [
-        'distributionId',
-        'eventType',
-        'pathPattern',
-        'includeBody'
-      ]
-    })
-
+        required: ['distributionId', 'eventType', 'pathPattern', 'includeBody']
+      })
+    }
   }
 
   checkAllowedDeployStage() {
@@ -162,7 +158,6 @@ class ServerlessLambdaEdgePreExistingCloudFront {
     })
     return arn
   }
-
 }
 
 module.exports = ServerlessLambdaEdgePreExistingCloudFront


### PR DESCRIPTION
This change is required to make the plugin work with older versions of Serverless Framework, before the `this.serverless.configSchemaHandler` was introduced.

The error that you would get is:

```
  TypeError: Cannot read property 'defineCustomProperties' of undefined
```

I have tested this with v1.70 and v2.2.0`

Some other users have been experiencing this issue: https://github.com/serverless-operations/serverless-lambda-edge-pre-existing-cloudfront/commit/e8ecb9f1083d2539b35feec0132162010e4f970d#commitcomment-41741520