### PR TITLE
fix: retry on stale ETag

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,35 +27,55 @@ class ServerlessLambdaEdgePreExistingCloudFront {
               for (let idx = 0; idx < events.length; idx += 1) {
                 const event = events[idx]
                 const functionArn = await this.getlatestVersionLambdaArn(functionObj.name)
-                const config = await this.provider.request('CloudFront', 'getDistribution', {
-                  Id: event.preExistingCloudFront.distributionId
-                })
-
-                if (event.preExistingCloudFront.pathPattern === '*') {
-                  config.DistributionConfig.DefaultCacheBehavior.LambdaFunctionAssociations = await this.associateFunction(
-                    config.DistributionConfig.DefaultCacheBehavior.LambdaFunctionAssociations,
-                    event,
-                    functionObj.name,
-                    functionArn
-                  )
-                } else {
-                  config.DistributionConfig.CacheBehaviors = await this.associateNonDefaultCacheBehaviors(
-                    config.DistributionConfig.CacheBehaviors,
-                    event,
-                    functionObj.name,
-                    functionArn
-                  )
-                }
 
                 this.serverless.cli.consoleLog(
                   `${functionArn} is associating to ${event.preExistingCloudFront.distributionId} CloudFront Distribution. waiting for deployed status.`
                 )
 
-                await this.provider.request('CloudFront', 'updateDistribution', {
-                  Id: event.preExistingCloudFront.distributionId,
-                  IfMatch: config.ETag,
-                  DistributionConfig: config.DistributionConfig
-                })
+                let retryCount = 5
+
+                const updateDistribution = async () => {
+                  const config = await this.provider.request('CloudFront', 'getDistribution', {
+                    Id: event.preExistingCloudFront.distributionId
+                  })
+
+                  if (event.preExistingCloudFront.pathPattern === '*') {
+                    config.DistributionConfig.DefaultCacheBehavior.LambdaFunctionAssociations = await this.associateFunction(
+                      config.DistributionConfig.DefaultCacheBehavior.LambdaFunctionAssociations,
+                      event,
+                      functionObj.name,
+                      functionArn
+                    )
+                  } else {
+                    config.DistributionConfig.CacheBehaviors = await this.associateNonDefaultCacheBehaviors(
+                      config.DistributionConfig.CacheBehaviors,
+                      event,
+                      functionObj.name,
+                      functionArn
+                    )
+                  }
+
+                  await this.provider
+                    .request('CloudFront', 'updateDistribution', {
+                      Id: event.preExistingCloudFront.distributionId,
+                      IfMatch: config.ETag,
+                      DistributionConfig: config.DistributionConfig
+                    })
+                    .catch(async (error) => {
+                      if (error.providerError.code === 'PreconditionFailed' && retryCount > 0) {
+                        this.serverless.cli.consoleLog(
+                          `received precondition failed error, retrying... (${retryCount}/5)`
+                        )
+                        retryCount -= 1
+                        await new Promise((res) => setTimeout(res, 5000))
+                        return updateDistribution()
+                      }
+                      this.serverless.cli.consoleLog(error)
+                      throw error
+                    })
+                }
+
+                await updateDistribution()
               }
             })
           }, Promise.resolve())


### PR DESCRIPTION
I kept facing this error from time to time:

```
arn:aws:lambda:us-east-1:*****:function:*****:91 is associating to ***** CloudFront Distribution. waiting for deployed status.
arn:aws:lambda:us-east-1:*****:function:*****:91 is associating to ***** CloudFront Distribution. waiting for deployed status.
arn:aws:lambda:us-east-1:*****:function:*****:21 is associating to ***** CloudFront Distribution. waiting for deployed status.
arn:aws:lambda:us-east-1:*****:function:*****:26 is associating to ***** CloudFront Distribution. waiting for deployed status.
arn:aws:lambda:us-east-1:*****:function:*****:18 is associating to ***** CloudFront Distribution. waiting for deployed status.
Serverless: Recoverable error occurred (Rate exceeded), sleeping for ~5 seconds. Try 1 of 4
arn:aws:lambda:us-east-1:*****:function:*****:58 is associating to ***** CloudFront Distribution. waiting for deployed status.
arn:aws:lambda:us-east-1:*****:function:*****:13 is associating to ***** CloudFront Distribution. waiting for deployed status.
Serverless: Recoverable error occurred (Rate exceeded), sleeping for ~5 seconds. Try 1 of 4
 
  Serverless Error ---------------------------------------
 
  The request failed because it didn't meet the preconditions in one or more request-header fields.
 
  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com
 
  Your Environment Information ---------------------------
     Operating System:          linux
     Node Version:              12.18.4
     Framework Version:         1.82.0 (local)
     Plugin Version:            3.8.3
     SDK Version:               2.3.1
     Components Version:        2.34.9
```

Did some googling and found:
https://www.pulumi.com/docs/tutorials/aws/aws-ts-static-website/#preconditionfailed-the-request-failed-because-it-didn-t-meet-the-preconditions

> This is caused by CloudFront confirming the ETag of the resource before applying any updates. ETag is essentially a “version”, and AWS is rejecting any requests that are trying to update any version but the “latest”.

So I am guessing this error happens when multiple function updates are requested into single Cloudfront distribution consecutively.

This patch wraps config generation routine (which includes (re)fetching latest CF ETag) and `updateDistribution` request into an async function and retries if faced with `PreconditionFailed` error (max 5 retries with 5 seconds delay).

With this patch, the above error is handled as followed:

```
arn:aws:lambda:us-east-1:*****:function:*****:97 is associating to ***** CloudFront Distribution. waiting for deployed status.
arn:aws:lambda:us-east-1:*****:function:*****:97 is associating to ***** CloudFront Distribution. waiting for deployed status.
arn:aws:lambda:us-east-1:*****:function:*****:22 is associating to ***** CloudFront Distribution. waiting for deployed status.
arn:aws:lambda:us-east-1:*****:function:*****:27 is associating to ***** CloudFront Distribution. waiting for deployed status.
arn:aws:lambda:us-east-1:*****:function:*****:19 is associating to ***** CloudFront Distribution. waiting for deployed status.
arn:aws:lambda:us-east-1:*****:function:*****:64 is associating to ***** CloudFront Distribution. waiting for deployed status.
arn:aws:lambda:us-east-1:*****:function:*****:14 is associating to ***** CloudFront Distribution. waiting for deployed status.
received precondition failed error, retrying... (5/5)
Done in 141.27s.
```