### PR TITLE
Support Fn::ImportValue as distribution id

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,9 +23,6 @@ class ServerlessLambdaEdgePreExistingCloudFront {
               const events = functionObj.events.filter(
                 (event) => event.preExistingCloudFront && this.checkAllowedDeployStage()
               )
-              this.serverless.cli.consoleLog(
-                `${functionArn} is associating to ${resolvedDistributionId} CloudFront Distribution. waiting for deployed status.`
-              )
               for (let idx = 0; idx < events.length; idx += 1) {
                 const event = events[idx]
 
@@ -36,6 +33,9 @@ class ServerlessLambdaEdgePreExistingCloudFront {
                 const resolvedDistributionId = await (event.preExistingCloudFront.distributionId['Fn::ImportValue']
                     ? this.resolveCfImportValue(this.provider, event.preExistingCloudFront.distributionId['Fn::ImportValue'])
                     : event.preExistingCloudFront.distributionId
+                )
+                this.serverless.cli.consoleLog(
+                  `${functionArn} (Event: ${event.preExistingCloudFront.eventType}, pathPattern: ${event.preExistingCloudFront.pathPattern}) is associating to ${resolvedDistributionId} CloudFront Distribution. waiting for deployed status.`
                 )
 
                 let retryCount = 5

--- a/index.js
+++ b/index.js
@@ -82,8 +82,6 @@ class ServerlessLambdaEdgePreExistingCloudFront {
                 }
 
                 await updateDistribution()
-
-                this.serverless.cli.consoleLog(`Event ${event.preExistingCloudFront.eventType - event.preExistingCloudFront.pathPattern} has been successfully associated to ${resolvedDistributionId} CloudFront Distribution.`)
               }
             })
           }, Promise.resolve())

--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ class ServerlessLambdaEdgePreExistingCloudFront {
               const events = functionObj.events.filter(
                 (event) => event.preExistingCloudFront && this.checkAllowedDeployStage()
               )
-
+              this.serverless.cli.consoleLog(
+                `${functionArn} is associating to ${resolvedDistributionId} CloudFront Distribution. waiting for deployed status.`
+              )
               for (let idx = 0; idx < events.length; idx += 1) {
                 const event = events[idx]
 
@@ -34,9 +36,6 @@ class ServerlessLambdaEdgePreExistingCloudFront {
                 const resolvedDistributionId = await (event.preExistingCloudFront.distributionId['Fn::ImportValue']
                     ? this.resolveCfImportValue(this.provider, event.preExistingCloudFront.distributionId['Fn::ImportValue'])
                     : event.preExistingCloudFront.distributionId
-                )
-                this.serverless.cli.consoleLog(
-                  `${functionArn} is associating to ${resolvedDistributionId} CloudFront Distribution. waiting for deployed status.`
                 )
 
                 let retryCount = 5
@@ -83,7 +82,8 @@ class ServerlessLambdaEdgePreExistingCloudFront {
                 }
 
                 await updateDistribution()
-                this.serverless.cli.consoleLog(`${functionArn} has been successfully associated to ${resolvedDistributionId} CloudFront Distribution.`)
+
+                this.serverless.cli.consoleLog(`Event ${event.preExistingCloudFront.eventType - event.preExistingCloudFront.pathPattern} has been successfully associated to ${resolvedDistributionId} CloudFront Distribution.`)
               }
             })
           }, Promise.resolve())

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-lambda-edge-pre-existing-cloudfront",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-lambda-edge-pre-existing-cloudfront",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "The Serverless Framework plugin which creates Lambda@Edge against pre-existing CloudFront.",
   "main": "index.js",
   "author": "serverless-operations",


### PR DESCRIPTION
This PR adds support for distribution id specified as an intrinsic function `Fn::ImportValue` 
Example:
```
      - preExistingCloudFront:
          distributionId:
            'Fn::ImportValue': 'CloudFront-SomeDistribution::CloudFrontID'
```

Currently this is not supported and the following error is returned upon deploy
```
Expected params.Id to be a string
```
