### PR TITLE
Fix the stage option through CLI is not applied

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ class ServerlessLambdaEdgePreExistingCloudFront {
                 const event = events[idx]
 
                 if (event.preExistingCloudFront.stage !== undefined &&
-                  event.preExistingCloudFront.stage != `${serverless.service.provider.stage}`) { continue }
+                  event.preExistingCloudFront.stage != `${this.stage}`) { continue }
 
                 const functionArn = await this.getlatestVersionLambdaArn(functionObj.name)
                 const resolvedDistributionId = await (event.preExistingCloudFront.distributionId['Fn::ImportValue']


### PR DESCRIPTION
Hello, I'm Charles and I'm glad that I can contribute to the awesome plugin. If I have missed some guidelines to contribute, please feel free to know to reissue the PR.

I have found an issue that the plugin is not respecting the `--stage` CLI option.

When I have two stages: staging and prod with different distributionIDs, I thought the following config and the command should work.

serverless.yml
```yaml
provider:
  name: aws
  runtime: nodejs14.x
  region: us-east-1
  stage: staging

custom:
  lambdaEdgePreExistingCloudFront:
    validStages:
      - staging
      - prod

functions:
  origin-request:
    handler: src/origin-request/index.handler
    memorySize: 128
    timeout: 30
    role: lambdaRole
    events:
      - preExistingCloudFront:
          distributionId: PRODDISTID
          eventType: origin-request
          pathPattern: '*'
          includeBody: true
          stage: prod
      - preExistingCloudFront:
          distributionId: STAGINGDISTID
          eventType: origin-request
          pathPattern: '*'
          includeBody: true
          stage: staging
...
```

```bash
$ serverless deploy --stage prod
```

However, because it's using a stage variable inside the provider which is a default stage value, not the current stage that serverless is deploying, it is not working as expected. 

The serverless has deployed the lambda function to the prod environment but the plugin is updating the staging environment even if the stage option has been set as 'prod'. 

This simple PR is fixing the above issue. 